### PR TITLE
Combined dependency updates (2023-07-27)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build javadoc
         run: mvn install -DskipTests=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.7
+        uses: mikepenz/action-junit-report@v3.8.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 		  <groupId>io.github.javiertuya</groupId>
 		  <artifactId>visual-assert</artifactId>
-		  <version>2.3.0</version>
+		  <version>2.4.1</version>
 		</dependency>
 
 		<!-- drivers de base de datos -->

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<!-- Sets the VM argument line used when unit tests are run under JaCoCo -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.1</version>
+			<version>2.15.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Includes these updates:
- [Bump actions/upload-pages-artifact from 1 to 2](https://github.com/javiertuya/samples-test-dev/pull/54)
- [Bump mikepenz/action-junit-report from 3.7.7 to 3.8.0](https://github.com/javiertuya/samples-test-dev/pull/55)
- [Bump jackson-databind from 2.15.1 to 2.15.2](https://github.com/javiertuya/samples-test-dev/pull/49)
- [Bump visual-assert from 2.3.0 to 2.4.1](https://github.com/javiertuya/samples-test-dev/pull/52)
- [Bump maven-surefire-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-dev/pull/50)
- [Bump maven-surefire-report-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-dev/pull/51)