### PR TITLE
Combined dependency updates (2023-08-26)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.42.0.0</version>
+			<version>3.42.0.1</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>commons-dbutils</groupId>
 			<artifactId>commons-dbutils</artifactId>
-			<version>1.7</version>
+			<version>1.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.13</version>
+						<version>1.10.14</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump commons-dbutils:commons-dbutils from 1.7 to 1.8.0](https://github.com/javiertuya/samples-test-dev/pull/57)
- [Bump org.apache.ant:ant-junit from 1.10.13 to 1.10.14](https://github.com/javiertuya/samples-test-dev/pull/59)
- [Bump org.xerial:sqlite-jdbc from 3.42.0.0 to 3.42.0.1](https://github.com/javiertuya/samples-test-dev/pull/58)