### PR TITLE
Combined dependency updates (2023-10-20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.3
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.10</version>
+				<version>0.8.11</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.43.2.0</version>
+			<version>3.43.2.1</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.1 to 4.0.3](https://github.com/javiertuya/samples-test-dev/pull/74)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.10 to 0.8.11](https://github.com/javiertuya/samples-test-dev/pull/76)
- [Bump org.xerial:sqlite-jdbc from 3.43.2.0 to 3.43.2.1](https://github.com/javiertuya/samples-test-dev/pull/75)