### PR TITLE
Combined dependency updates (2023-11-04)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<surefire.version>3.1.2</surefire.version>
+		<surefire.version>3.2.1</surefire.version>
 		<slf4j.version>2.0.9</slf4j.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.43.2.1</version>
+			<version>3.43.2.2</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump org.xerial:sqlite-jdbc from 3.43.2.1 to 3.43.2.2](https://github.com/javiertuya/samples-test-dev/pull/79)
- [Bump surefire.version from 3.1.2 to 3.2.1](https://github.com/javiertuya/samples-test-dev/pull/78)