### PR TITLE
Combined dependency updates (2023-12-08)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Select Java Version
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,4 +48,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2.0.4
+        uses: actions/deploy-pages@v3.0.1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Select Java Version
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.6.2</version>
+				<version>3.6.3</version>
 				<configuration>
 					<overview>${basedir}/src/main/java/overview.html</overview>
 					<sourcepath>${basedir}/src/main/java;${basedir}/src/test/java;${basedir}/src/it/java</sourcepath>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.44.0.0</version>
+			<version>3.44.1.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/configure-pages from 3 to 4](https://github.com/javiertuya/samples-test-dev/pull/90)
- [Bump actions/deploy-pages from 2.0.4 to 3.0.1](https://github.com/javiertuya/samples-test-dev/pull/89)
- [Bump actions/setup-java from 3 to 4](https://github.com/javiertuya/samples-test-dev/pull/87)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.2 to 3.6.3](https://github.com/javiertuya/samples-test-dev/pull/88)
- [Bump org.xerial:sqlite-jdbc from 3.44.0.0 to 3.44.1.0](https://github.com/javiertuya/samples-test-dev/pull/86)