### PR TITLE
Combined dependency updates (2024-02-04)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,4 +48,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.2
+        uses: actions/deploy-pages@v4.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.3
+        uses: mikepenz/action-junit-report@v4.1.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		
 		<surefire.version>3.2.3</surefire.version>
 		
-		<slf4j.version>2.0.10</slf4j.version>
+		<slf4j.version>2.0.11</slf4j.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<surefire.version>3.2.3</surefire.version>
+		<surefire.version>3.2.5</surefire.version>
 		
 		<slf4j.version>2.0.11</slf4j.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.44.1.0</version>
+			<version>3.45.1.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 4.0.2 to 4.0.3](https://github.com/javiertuya/samples-test-dev/pull/104)
- [Bump mikepenz/action-junit-report from 4.0.3 to 4.1.0](https://github.com/javiertuya/samples-test-dev/pull/103)
- [Bump org.xerial:sqlite-jdbc from 3.44.1.0 to 3.45.1.0](https://github.com/javiertuya/samples-test-dev/pull/101)
- [Bump slf4j.version from 2.0.10 to 2.0.11](https://github.com/javiertuya/samples-test-dev/pull/100)
- [Bump surefire.version from 3.2.3 to 3.2.5](https://github.com/javiertuya/samples-test-dev/pull/102)