### PR TITLE
Combined dependency updates (2024-07-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.2.2
+        uses: mikepenz/action-junit-report@v4.3.1
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 		  <groupId>io.github.javiertuya</groupId>
 		  <artifactId>visual-assert</artifactId>
-		  <version>2.4.1</version>
+		  <version>2.4.2</version>
 		</dependency>
 
 		<!-- drivers de base de datos -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<surefire.version>3.2.5</surefire.version>
+		<surefire.version>3.3.0</surefire.version>
 		
 		<slf4j.version>2.0.13</slf4j.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.32</version>
+			<version>1.18.34</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 4.2.2 to 4.3.1](https://github.com/javiertuya/samples-test-dev/pull/129)
- [Bump org.projectlombok:lombok from 1.18.32 to 1.18.34](https://github.com/javiertuya/samples-test-dev/pull/128)
- [Bump io.github.javiertuya:visual-assert from 2.4.1 to 2.4.2](https://github.com/javiertuya/samples-test-dev/pull/127)
- [Bump surefire.version from 3.2.5 to 3.3.0](https://github.com/javiertuya/samples-test-dev/pull/126)