### PR TITLE
Combined dependency updates (2024-08-03)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.46.0.0</version>
+			<version>3.46.0.1</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.xerial:sqlite-jdbc from 3.46.0.0 to 3.46.0.1](https://github.com/javiertuya/samples-test-dev/pull/134)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.17.1 to 2.17.2](https://github.com/javiertuya/samples-test-dev/pull/133)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0](https://github.com/javiertuya/samples-test-dev/pull/132)
- [Bump surefire.version from 3.3.0 to 3.3.1](https://github.com/javiertuya/samples-test-dev/pull/131)