### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.14</version>
+						<version>1.10.15</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.ant:ant-junit from 1.10.14 to 1.10.15](https://github.com/javiertuya/samples-test-dev/pull/141)
- [Bump surefire.version from 3.3.1 to 3.5.0](https://github.com/javiertuya/samples-test-dev/pull/140)
- [Bump io.github.javiertuya:visual-assert from 2.4.2 to 2.5.0](https://github.com/javiertuya/samples-test-dev/pull/139)
- [Bump org.xerial:sqlite-jdbc from 3.46.0.1 to 3.46.1.0](https://github.com/javiertuya/samples-test-dev/pull/138)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0](https://github.com/javiertuya/samples-test-dev/pull/137)
- [Bump slf4j.version from 2.0.13 to 2.0.16](https://github.com/javiertuya/samples-test-dev/pull/136)