### PR TITLE
Combined dependency updates (2024-10-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.17.2</version>
+			<version>2.18.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.17.2 to 2.18.0](https://github.com/javiertuya/samples-test-dev/pull/145)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.10.0 to 3.10.1](https://github.com/javiertuya/samples-test-dev/pull/144)
- [Bump org.xerial:sqlite-jdbc from 3.46.1.0 to 3.46.1.3](https://github.com/javiertuya/samples-test-dev/pull/143)