### PR TITLE
Combined dependency updates (2024-11-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.46.1.3</version>
+			<version>3.47.0.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.xerial:sqlite-jdbc from 3.46.1.3 to 3.47.0.0](https://github.com/javiertuya/samples-test-dev/pull/150)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.0 to 2.18.1](https://github.com/javiertuya/samples-test-dev/pull/149)
- [Bump io.github.javiertuya:visual-assert from 2.5.0 to 2.5.1](https://github.com/javiertuya/samples-test-dev/pull/148)
- [Bump surefire.version from 3.5.0 to 3.5.1](https://github.com/javiertuya/samples-test-dev/pull/147)