### PR TITLE
Combined dependency updates (2025-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.3.0
+        uses: mikepenz/action-junit-report@v5.4.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.49.0.0</version>
+			<version>3.49.1.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.10.0</version>
+			<version>1.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		
 		<surefire.version>3.5.2</surefire.version>
 		
-		<slf4j.version>2.0.16</slf4j.version>
+		<slf4j.version>2.0.17</slf4j.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.18.2</version>
+			<version>2.18.3</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.xerial:sqlite-jdbc from 3.49.0.0 to 3.49.1.0](https://github.com/javiertuya/samples-test-dev/pull/172)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.2 to 2.18.3](https://github.com/javiertuya/samples-test-dev/pull/171)
- [Bump commons-beanutils:commons-beanutils from 1.10.0 to 1.10.1](https://github.com/javiertuya/samples-test-dev/pull/170)
- [Bump slf4j.version from 2.0.16 to 2.0.17](https://github.com/javiertuya/samples-test-dev/pull/169)
- [Bump mikepenz/action-junit-report from 5.3.0 to 5.4.0](https://github.com/javiertuya/samples-test-dev/pull/168)