### PR TITLE
Combined dependency updates (2025-05-03)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.18.3</version>
+			<version>2.19.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.3 to 2.19.0](https://github.com/javiertuya/samples-test-dev/pull/180)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.12 to 0.8.13](https://github.com/javiertuya/samples-test-dev/pull/179)