### PR TITLE
Combined dependency updates (2025-09-02)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Select Java Version

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build javadoc
         run: mvn install -DskipTests=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'target/reports/testapidocs'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.19.2</version>
+			<version>2.20.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.11.3</version>
 				<configuration>
 					<overview>${basedir}/src/main/java/overview.html</overview>
 					<sourcepath>${basedir}/src/main/java;${basedir}/src/test/java;${basedir}/src/it/java</sourcepath>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.19.2 to 2.20.0](https://github.com/javiertuya/samples-test-dev/pull/199)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.2 to 3.11.3](https://github.com/javiertuya/samples-test-dev/pull/198)
- [Bump actions/setup-java from 4 to 5](https://github.com/javiertuya/samples-test-dev/pull/197)
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/samples-test-dev/pull/196)
- [Bump actions/upload-pages-artifact from 3 to 4](https://github.com/javiertuya/samples-test-dev/pull/195)