### PR TITLE
Combined dependency updates (2026-02-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.1.0
+        uses: mikepenz/action-junit-report@v6.2.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<junit.version>6.0.1</junit.version>
+		<junit.version>6.0.2</junit.version>
 		
 		<surefire.version>3.5.4</surefire.version>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.20.1</version>
+			<version>2.21.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.20.1 to 2.21.0](https://github.com/javiertuya/samples-test-dev/pull/219)
- [Bump junit.version from 6.0.1 to 6.0.2](https://github.com/javiertuya/samples-test-dev/pull/218)
- [Bump mikepenz/action-junit-report from 6.1.0 to 6.2.0](https://github.com/javiertuya/samples-test-dev/pull/217)