### PR TITLE
Combined dependency updates (2026-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.2.0
+        uses: mikepenz/action-junit-report@v6.3.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
  
       - if: always()
         name: Publish html test reports to an artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports-files
           path: |

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.51.1.0</version>
+			<version>3.51.2.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.21.0</version>
+			<version>2.21.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<junit.version>6.0.2</junit.version>
+		<junit.version>6.0.3</junit.version>
 		
 		<surefire.version>3.5.4</surefire.version>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		
 		<junit.version>6.0.2</junit.version>
 		
-		<surefire.version>3.5.4</surefire.version>
+		<surefire.version>3.5.5</surefire.version>
 		
 		<slf4j.version>2.0.17</slf4j.version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.21.0 to 2.21.1](https://github.com/javiertuya/samples-test-dev/pull/226)
- [Bump org.xerial:sqlite-jdbc from 3.51.1.0 to 3.51.2.0](https://github.com/javiertuya/samples-test-dev/pull/225)
- [Bump surefire.version from 3.5.4 to 3.5.5](https://github.com/javiertuya/samples-test-dev/pull/224)
- [Bump junit.version from 6.0.2 to 6.0.3](https://github.com/javiertuya/samples-test-dev/pull/223)
- [Bump mikepenz/action-junit-report from 6.2.0 to 6.3.0](https://github.com/javiertuya/samples-test-dev/pull/222)
- [Bump actions/upload-artifact from 6 to 7](https://github.com/javiertuya/samples-test-dev/pull/221)