### PR TITLE
Combined dependency updates (2026-04-05)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,4 +48,4 @@ jobs:
           path: 'target/reports/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.3.0
+        uses: mikepenz/action-junit-report@v6.4.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.42</version>
+			<version>1.18.44</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.15</version>
+						<version>1.10.16</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.51.2.0</version>
+			<version>3.51.3.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.21.1</version>
+			<version>2.21.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 6.3.0 to 6.4.0](https://github.com/javiertuya/samples-test-dev/pull/234)
- [Bump actions/configure-pages from 5 to 6](https://github.com/javiertuya/samples-test-dev/pull/233)
- [Bump actions/deploy-pages from 4.0.5 to 5.0.0](https://github.com/javiertuya/samples-test-dev/pull/232)
- [Bump org.xerial:sqlite-jdbc from 3.51.2.0 to 3.51.3.0](https://github.com/javiertuya/samples-test-dev/pull/231)
- [Bump org.projectlombok:lombok from 1.18.42 to 1.18.44](https://github.com/javiertuya/samples-test-dev/pull/230)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.21.1 to 2.21.2](https://github.com/javiertuya/samples-test-dev/pull/229)
- [Bump org.apache.ant:ant-junit from 1.10.15 to 1.10.16](https://github.com/javiertuya/samples-test-dev/pull/228)