### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build javadoc
         run: mvn install -DskipTests=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'target/reports/testapidocs'
       - name: Deploy to GitHub Pages

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.51.3.0</version>
+			<version>3.53.0.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.44</version>
+			<version>1.18.46</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant-junit</artifactId>
-						<version>1.10.16</version>
+						<version>1.10.17</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.21.2</version>
+			<version>2.21.3</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.projectlombok:lombok from 1.18.44 to 1.18.46](https://github.com/javiertuya/samples-test-dev/pull/240)
- [Bump org.xerial:sqlite-jdbc from 3.51.3.0 to 3.53.0.0](https://github.com/javiertuya/samples-test-dev/pull/239)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.21.2 to 2.21.3](https://github.com/javiertuya/samples-test-dev/pull/238)
- [Bump actions/upload-pages-artifact from 4 to 5](https://github.com/javiertuya/samples-test-dev/pull/237)
- [Bump org.apache.ant:ant-junit from 1.10.16 to 1.10.17](https://github.com/javiertuya/samples-test-dev/pull/236)