### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		
 		<surefire.version>3.5.5</surefire.version>
 		
-		<slf4j.version>2.0.17</slf4j.version>
+		<slf4j.version>2.0.18</slf4j.version>
 		
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<junit.version>6.0.3</junit.version>
+		<junit.version>6.1.0</junit.version>
 		
 		<surefire.version>3.5.5</surefire.version>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		
 		<junit.version>6.0.3</junit.version>
 		
-		<surefire.version>3.5.5</surefire.version>
+		<surefire.version>3.5.6</surefire.version>
 		
 		<slf4j.version>2.0.17</slf4j.version>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.53.0.0</version>
+			<version>3.53.1.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.xerial:sqlite-jdbc from 3.53.0.0 to 3.53.1.0](https://github.com/javiertuya/samples-test-dev/pull/247)
- [Bump surefire.version from 3.5.5 to 3.5.6](https://github.com/javiertuya/samples-test-dev/pull/245)
- [Bump slf4j.version from 2.0.17 to 2.0.18](https://github.com/javiertuya/samples-test-dev/pull/244)
- [Bump junit.version from 6.0.3 to 6.1.0](https://github.com/javiertuya/samples-test-dev/pull/243)
- [Bump mikepenz/action-junit-report from 6.4.0 to 6.4.1](https://github.com/javiertuya/samples-test-dev/pull/242)